### PR TITLE
Add documentation (2)

### DIFF
--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -307,6 +307,13 @@ defmodule ChalkAuthorization do
         end
       end
 
+      @doc """
+      Grant or revoke a user the role of superuser (all permissions).
+
+      `user` can be a map. `boolean` can be `true` or `false`.
+
+      Returns `true` or `false`.
+      """
       def set_superuser(%{superuser: _} = user, boolean) when is_boolean(boolean),
         do:
           user

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -254,6 +254,13 @@ defmodule ChalkAuthorization do
       end
 
       @doc nil
+      @doc """
+      Convert a string of permissions into an integer.
+
+      `string` can be a string.
+
+      Returns an integer.
+      """
       defp permissions_string_to_int(string) do
         string
         |> String.graphemes()

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -74,13 +74,9 @@ defmodule ChalkAuthorization do
           |> permissions_int_to_string
           |> String.contains?(permission)
 
-      @doc """
-      Get the permissions of a specific group and upgrade the user's permissions
-      according to the ones given to the group.
-
-      `user` can be a map and `group` an atom.
-
-      Returns a map with the user, the user's permissions and the group's permissions.
+      """
+      Get the permissions of a specific group and upgrade the user's
+      permissions according to the ones given to the group.
       """
       defp get_group_permissions(),
         do: unquote(group_permissions) || %{}
@@ -94,15 +90,11 @@ defmodule ChalkAuthorization do
             else: user
           )
 
-      @doc """
-      Upgrade the users permissions according to the ones given to the group.
-
-      If the user has higher permissions than the group given or the user is in
-      a group with higher permissions, the permissions aren't upgraded.
-
-      `permissions` can be a map. `group_permissions` can be a map or a list.
-
-      Returns a map with the permissions.
+      """
+      Upgrade the users permissions according to the ones given
+      to the group. If the user has higher permissions than the
+      group given or the user is in a group with higher permissions,
+      the permissions aren't upgraded.
       """
       defp upgrade_to_group(%{permissions: permissions} = user, group_permissions),
         do:
@@ -253,13 +245,8 @@ defmodule ChalkAuthorization do
         end
       end
 
-      @doc nil
-      @doc """
+      """
       Convert a string of permissions into an integer.
-
-      `string` can be a string.
-
-      Returns an integer.
       """
       defp permissions_string_to_int(string) do
         string
@@ -269,16 +256,8 @@ defmodule ChalkAuthorization do
         |> Enum.sum()
       end
 
-      @doc """
+      """
       Convert an integer permission into a string.
-
-      `int` and `rest` can be an integer.
-
-      The second parameter is a list.
-
-      `acc` can be a list.
-
-      Returns a string with the permissions or an error.
       """
       defp permissions_int_to_string(int) when is_integer(int) do
         keys =

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -269,7 +269,17 @@ defmodule ChalkAuthorization do
         |> Enum.sum()
       end
 
-      @doc nil
+      @doc """
+      Convert an integer permission into a string.
+
+      `int` and `rest` can be an integer.
+
+      The second parameter is a list.
+
+      `acc` can be a list.
+
+      Returns a string with the permissions or an error.
+      """
       defp permissions_int_to_string(int) when is_integer(int) do
         keys =
           Map.keys(permission_map())

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -16,15 +16,73 @@ defmodule ChalkAuthorization do
 
   Get the changeset to update the permissions.
 
-  * `item` can be an atom or a string.
-  * `attrs` can be a...
+  - `item` can be an atom or a string.
+  - `attrs` can be a...
 
   ## `can?(user, permission, element)`
 
   Check if a user has permission to perform an action on a specific element.
 
-  * `user` can be a map or nil.
-  * `permission` and `element`, both can be an atom or a string.
+  ### Parameters
+
+  - `user` can be a map or nil.
+  - `permission` and `element`, both can be an atom or a string.
+  
+  ## `get_permissions(user, element)`
+
+  Get the permissions of a user on an element.
+
+  ### Parameters
+  
+  - `user` can be a map.
+  - `element` can be an atom or a string.
+
+  ## `add_group(user, group)`
+  
+  Add a user to a specific group.
+
+  ### Parameters
+  
+  - `user` can be a map.
+  - `group` can be a string or a list of groups.
+
+  ## `remove_group(user, group)
+  
+  Add a user to a specific group.
+
+  ### Parameters
+      
+  - `user` can be a map.
+  - `group` can be a string or a list of groups.
+
+  ## `is_a?(user, group)
+
+  Check if the user is in a specific group.
+
+  ### Parameters
+
+  - `user` can be a map.
+  - `groups` can be a string, a bitstring or a list of groups.
+
+  ## set_permissions(user, element)
+  
+  Grant permissions to a user on an item.
+
+  ### Parameters
+
+  - `user` can be a map.
+  - `element` can be an atom or a string. `value` can 
+  be an integer or a string.
+
+  ## set_superuser(user, boolean)
+
+  Grant or revoke a user the role of superuser (all permissions).
+
+  ### Parameters
+  
+  - `user` can be a map.
+  - `boolean` can be `true` or `false`.
+
   """
   defmacro __using__(repo: repo, group_permissions: group_permissions) do
     quote do
@@ -327,7 +385,8 @@ defmodule ChalkAuthorization do
 
       ## Parameters
       
-      - `user` can be a map. `boolean` can be `true` or `false`.
+      - `user` can be a map.
+      - `boolean` can be `true` or `false`.
 
       ## Returns
       

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -143,7 +143,13 @@ defmodule ChalkAuthorization do
             else: 0
           )
 
-      @doc nil
+      @doc """
+      Add a user to a specific group.
+
+      `user` can be a map. `group` can be a string or a list of groups.
+
+      Returns the group or groups added to the user.
+      """
       def add_group(user, []),
         do: user
 

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -94,6 +94,16 @@ defmodule ChalkAuthorization do
             else: user
           )
 
+      @doc """
+      Upgrade the users permissions according to the ones given to the group.
+
+      If the user has higher permissions than the group given or the user is in
+      a group with higher permissions, the permissions aren't upgraded.
+
+      `permissions` can be a map. `group_permissions` can be a map or a list.
+
+      Returns a map with the permissions.
+      """
       defp upgrade_to_group(%{permissions: permissions} = user, group_permissions),
         do:
           Map.put(

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -36,6 +36,10 @@ defmodule ChalkAuthorization do
 
       @doc """
       Get the changeset to update the permissions.
+
+      `item` can be an atom or a string.
+
+      `attrs` can be a map.
       """
       def permissions_changeset(item, attrs),
         do: cast(item, attrs, [:superuser, :groups, :permissions])

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -193,7 +193,13 @@ defmodule ChalkAuthorization do
           |> unquote(repo).update()
           |> elem(1)
 
-      @doc nil
+      @doc """
+      Check if the user is in a specific group.
+
+      `user` can be a map. `groups` can be a string, a bitstring or a list of groups.
+
+      Returns `true` or `false`.
+      """
       def is_a?(user, groups) when is_list(groups),
         do: groups |> Enum.all?(fn g -> user |> is_a?(g) end)
 

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -74,7 +74,14 @@ defmodule ChalkAuthorization do
           |> permissions_int_to_string
           |> String.contains?(permission)
 
-      @doc nil
+      @doc """
+      Get the permissions of a specific group and upgrade the user's permissions
+      according to the ones given to the group.
+
+      `user` can be a map and `group` an atom.
+
+      Returns a map with the user, the user's permissions and the group's permissions.
+      """
       defp get_group_permissions(),
         do: unquote(group_permissions) || %{}
 

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -168,7 +168,13 @@ defmodule ChalkAuthorization do
           |> unquote(repo).update()
           |> elem(1)
 
-      @doc nil
+      @doc """
+      Remove a user from a specific group.
+
+      `user` can be a map. `group` can be a string, a bitstring or a list of groups.
+
+      Returns the group or groups added to the user.
+      """
       def remove_group(user, []),
         do: user
 

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -209,7 +209,14 @@ defmodule ChalkAuthorization do
       def is_a?(%{groups: groups}, group),
         do: Enum.member?(groups, group)
 
-      @doc nil
+      @doc """
+      Grant permissions to a user on an item.
+
+      `user` can be a map. `element` can be an atom or a string. `value` can
+      be an integer or a string.
+
+      Returns the `repo` updated or an error.
+      """
       def set_permissions(user, element, value) when is_atom(element),
         do: set_permissions(user, Atom.to_string(element), value)
 

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -37,9 +37,10 @@ defmodule ChalkAuthorization do
       @doc """
       Get the changeset to update the permissions.
 
-      `item` can be an atom or a string.
+      ## Parameters
 
-      `attrs` can be a map.
+      - `item`: can be an atom or a string.
+      - `attrs`: can be a map.
       """
       def permissions_changeset(item, attrs),
         do: cast(item, attrs, [:superuser, :groups, :permissions])
@@ -47,9 +48,15 @@ defmodule ChalkAuthorization do
       @doc """
       Check if a user has permission to perform an action on a specific element.
 
-      `user` can be a `map` or `nil`. `permission` and `element`, both can be an atom or a string.
+      ## Parameters
 
-      It returns `true` or `false`.
+      - `user`: can be a map or `nil`.
+      - `permission`: can be an atom or a string.
+      - `element`: can be an atom or a string.
+
+      ## Returns
+
+      `true` or `false`.
       """
       def can?(nil, _permission, _element),
         do: false
@@ -78,6 +85,7 @@ defmodule ChalkAuthorization do
       Get the permissions of a specific group and upgrade the user's
       permissions according to the ones given to the group.
       """
+
       defp get_group_permissions(),
         do: unquote(group_permissions) || %{}
 
@@ -96,6 +104,7 @@ defmodule ChalkAuthorization do
       group given or the user is in a group with higher permissions,
       the permissions aren't upgraded.
       """
+
       defp upgrade_to_group(%{permissions: permissions} = user, group_permissions),
         do:
           Map.put(
@@ -121,9 +130,14 @@ defmodule ChalkAuthorization do
       @doc """
       Get the permissions of a user on an element.
 
-      `user` can be a map. `element` can be an atom or a string.
+      ## Parameters
+      
+      - `user` can be a map.
+      - `element` can be an atom or a string.
 
-      Returns the permission of the user or `0`.
+      ## Returns
+
+      The permission of the user or `0`.
       """
       def get_permissions(user, element) when is_atom(element),
         do: get_permissions(user, Atom.to_string(element))
@@ -138,9 +152,14 @@ defmodule ChalkAuthorization do
       @doc """
       Add a user to a specific group.
 
-      `user` can be a map. `group` can be a string or a list of groups.
+      ## Parameters
+      
+      - `user` can be a map.
+      - `group` can be a string or a list of groups.
 
-      Returns the group or groups added to the user.
+      ## Returns
+
+      The group or groups added to the user.
       """
       def add_group(user, []),
         do: user
@@ -163,9 +182,14 @@ defmodule ChalkAuthorization do
       @doc """
       Remove a user from a specific group.
 
-      `user` can be a map. `group` can be a string, a bitstring or a list of groups.
+      ## Parameters
 
-      Returns the group or groups added to the user.
+      - `user` can be a map.
+      - `group` can be a string, a bitstring or a list of groups.
+
+      ## Returns
+
+      The group or groups added to the user.
       """
       def remove_group(user, []),
         do: user
@@ -188,9 +212,14 @@ defmodule ChalkAuthorization do
       @doc """
       Check if the user is in a specific group.
 
-      `user` can be a map. `groups` can be a string, a bitstring or a list of groups.
+      ## Parameters
 
-      Returns `true` or `false`.
+      - `user` can be a map.
+      - `groups` can be a string, a bitstring or a list of groups.
+
+      ## Returns
+
+      `true` or `false`.
       """
       def is_a?(user, groups) when is_list(groups),
         do: groups |> Enum.all?(fn g -> user |> is_a?(g) end)
@@ -204,10 +233,15 @@ defmodule ChalkAuthorization do
       @doc """
       Grant permissions to a user on an item.
 
-      `user` can be a map. `element` can be an atom or a string. `value` can
+      ## Parameters
+
+      - `user` can be a map.
+      - `element` can be an atom or a string. `value` can 
       be an integer or a string.
 
-      Returns the `repo` updated or an error.
+      ## Returns
+
+      The `repo` updated or an error.
       """
       def set_permissions(user, element, value) when is_atom(element),
         do: set_permissions(user, Atom.to_string(element), value)
@@ -248,6 +282,7 @@ defmodule ChalkAuthorization do
       """
       Convert a string of permissions into an integer.
       """
+
       defp permissions_string_to_int(string) do
         string
         |> String.graphemes()
@@ -259,6 +294,7 @@ defmodule ChalkAuthorization do
       """
       Convert an integer permission into a string.
       """
+
       defp permissions_int_to_string(int) when is_integer(int) do
         keys =
           Map.keys(permission_map())
@@ -289,9 +325,13 @@ defmodule ChalkAuthorization do
       @doc """
       Grant or revoke a user the role of superuser (all permissions).
 
-      `user` can be a map. `boolean` can be `true` or `false`.
+      ## Parameters
+      
+      - `user` can be a map. `boolean` can be `true` or `false`.
 
-      Returns `true` or `false`.
+      ## Returns
+      
+      `true` or `false`.
       """
       def set_superuser(%{superuser: _} = user, boolean) when is_boolean(boolean),
         do:

--- a/lib/chalk_authorization.ex
+++ b/lib/chalk_authorization.ex
@@ -126,7 +126,13 @@ defmodule ChalkAuthorization do
               |> upgrade_to_group(group_permissions)
           )
 
-      @doc nil
+      @doc """
+      Get the permissions of a user on an element.
+
+      `user` can be a map. `element` can be an atom or a string.
+
+      Returns the permission of the user or `0`.
+      """
       def get_permissions(user, element) when is_atom(element),
         do: get_permissions(user, Atom.to_string(element))
 


### PR DESCRIPTION
This PR follows the line of #1. 

We should keep in mind that the private functions returns a warning indicating that their documentation is always discarded. Let's see an example:

```
warning: defp permissions_int_to_string/1 is private, @doc attribute is always discarded for private functions/macros/types
```

It remains to give the correct format to the documentation, add examples and write the summary of each function in the module documentation to have it available in the Hex docs.